### PR TITLE
Ensures that only the market data session is using the memory store

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -81,10 +81,12 @@ func NewInitiator(app Application, storeFactory MessageStoreFactory, appSettings
 	}
 
 	for sessionID, s := range i.sessionSettings {
+		store := storeFactory
+		// We use a memory store for the market data session since we don't need to persist it
 		if sessionID.TargetCompID == "OmniexFeed" {
-			storeFactory = NewMemoryStoreFactory()
+			store = NewMemoryStoreFactory()
 		}
-		session, err := i.createSession(sessionID, storeFactory, s, logFactory, app)
+		session, err := i.createSession(sessionID, store, s, logFactory, app)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
previously i was overwriting the storeFactory variable, so the order session was occasionally using an in memory store if the ordering was just right