### PR TITLE
Changes Incoming/Outgoing Message Chans to Buffered Chans

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-var messageBufferChanSize = 1000
+var messageBufferChanSize = 10000
 
 //Initiator initiates connections and processes messages for all sessions.
 type Initiator struct {

--- a/initiator.go
+++ b/initiator.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/net/proxy"
 )
 
+var messageBufferChanSize = 1000
+
 //Initiator initiates connections and processes messages for all sessions.
 type Initiator struct {
 	app             Application
@@ -174,8 +176,8 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			netConn = tlsConn
 		}
 
-		msgIn = make(chan fixIn)
-		msgOut = make(chan []byte)
+		msgIn = make(chan fixIn, messageBufferChanSize)
+		msgOut = make(chan []byte, messageBufferChanSize)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
 			goto reconnect


### PR DESCRIPTION
I ran 1000 BTC/USD BUY PVWAP 1 HR Algo on 6 takers concurrently. This normally caused a Sending Time Accuracy issue, but we didn't see to hit it this time. I'll continue testing but I think we'll still want this in regardless.