### PR TITLE
Instrumented Build with Quickfix bottleneck improvements

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1,6 +1,9 @@
 package quickfix
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 func writeLoop(connection io.Writer, messageOut chan []byte, log Log) {
 	for {
@@ -23,6 +26,7 @@ func readLoop(parser *parser, msgIn chan fixIn) {
 		if err != nil {
 			return
 		}
+		fmt.Println(parser.lastRead, " RCV")
 		msgIn <- fixIn{msg, parser.lastRead}
 	}
 }

--- a/in_session.go
+++ b/in_session.go
@@ -2,6 +2,7 @@ package quickfix
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/quickfixgo/quickfix/internal"
@@ -12,6 +13,11 @@ type inSession struct{ loggedOn }
 func (state inSession) String() string { return "In Session" }
 
 func (state inSession) FixMsgIn(session *session, msg *Message) sessionState {
+	start := time.Now()
+	defer func() {
+		fmt.Println("FixMsgIn HEAT: ", time.Since(start))
+	}()
+
 	msgType, err := msg.Header.GetBytes(tagMsgType)
 	if err != nil {
 		return handleStateError(session, err)
@@ -44,7 +50,6 @@ func (state inSession) FixMsgIn(session *session, msg *Message) sessionState {
 	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {
 		return handleStateError(session, err)
 	}
-
 	return state
 }
 

--- a/initiator.go
+++ b/initiator.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-var messageBufferChanSize = 1000
+var messageBufferChanSize = 10000
 
 //Initiator initiates connections and processes messages for all sessions.
 type Initiator struct {

--- a/initiator.go
+++ b/initiator.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/net/proxy"
 )
 
+var messageBufferChanSize = 1000
+
 //Initiator initiates connections and processes messages for all sessions.
 type Initiator struct {
 	app             Application
@@ -174,8 +176,8 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			netConn = tlsConn
 		}
 
-		msgIn = make(chan fixIn)
-		msgOut = make(chan []byte)
+		msgIn = make(chan fixIn, messageBufferChanSize)
+		msgOut = make(chan []byte, messageBufferChanSize)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
 			goto reconnect

--- a/initiator.go
+++ b/initiator.go
@@ -178,6 +178,8 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 
 		msgIn = make(chan fixIn, messageBufferChanSize)
 		msgOut = make(chan []byte, messageBufferChanSize)
+		// msgIn = make(chan fixIn)
+		// msgOut = make(chan []byte)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
 			goto reconnect

--- a/message_router.go
+++ b/message_router.go
@@ -1,5 +1,10 @@
 package quickfix
 
+import (
+	"fmt"
+	"time"
+)
+
 type routeKey struct {
 	FIXVersion string
 	MsgType    string
@@ -39,6 +44,11 @@ func (c MessageRouter) AddRoute(beginString string, msgType string, router Messa
 
 //Route may be called from the fromApp/fromAdmin callbacks. Messages that cannot be routed will be rejected with UnsupportedMessageType.
 func (c MessageRouter) Route(msg *Message, sessionID SessionID) MessageRejectError {
+	start := time.Now()
+	defer func() {
+		fmt.Println("Route HEAT: ", time.Since(start))
+	}()
+
 	beginString, err := msg.Header.GetBytes(tagBeginString)
 	if err != nil {
 		return nil
@@ -53,6 +63,11 @@ func (c MessageRouter) Route(msg *Message, sessionID SessionID) MessageRejectErr
 }
 
 func (c MessageRouter) tryRoute(beginString string, msgType string, msg *Message, sessionID SessionID) MessageRejectError {
+	start := time.Now()
+	defer func() {
+		fmt.Println("tryRoute HEAT: ", time.Since(start))
+	}()
+
 	fixVersion := beginString
 	isAdminMsg := isAdminMessageType([]byte(msgType))
 

--- a/session.go
+++ b/session.go
@@ -490,6 +490,11 @@ func (s *session) verifyIgnoreSeqNumTooHighOrLow(msg *Message) MessageRejectErro
 }
 
 func (s *session) verifySelect(msg *Message, checkTooHigh bool, checkTooLow bool) MessageRejectError {
+	start := time.Now()
+	defer func() {
+		fmt.Println("verifySelect HEAT: ", time.Since(start))
+	}()
+
 	if reject := s.checkBeginString(msg); reject != nil {
 		return reject
 	}
@@ -524,6 +529,11 @@ func (s *session) verifySelect(msg *Message, checkTooHigh bool, checkTooLow bool
 }
 
 func (s *session) fromCallback(msg *Message) MessageRejectError {
+	start := time.Now()
+	defer func() {
+		fmt.Println("fromCallback HEAT: ", time.Since(start))
+	}()
+
 	msgType, err := msg.Header.GetBytes(tagMsgType)
 	if err != nil {
 		return err

--- a/session_state.go
+++ b/session_state.go
@@ -88,7 +88,9 @@ func (sm *stateMachine) Incoming(session *session, m fixIn) {
 		session.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), m.bytes)
 	} else {
 		msg.ReceiveTime = m.receiveTime
+		start := time.Now()
 		sm.fixMsgIn(session, msg)
+		fmt.Println("HEAT: ", time.Since(start))
 	}
 
 	if !msg.keepMessage {

--- a/store.go
+++ b/store.go
@@ -1,6 +1,9 @@
 package quickfix
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 //The MessageStore interface provides methods to record and retrieve messages for resend purposes
 type MessageStore interface {
@@ -49,6 +52,10 @@ func (store *memoryStore) IncrNextSenderMsgSeqNum() error {
 }
 
 func (store *memoryStore) IncrNextTargetMsgSeqNum() error {
+	start := time.Now()
+	defer func() {
+		fmt.Println("[CACHE] IncrNextTargetMsgSeqNum: ", time.Since(start))
+	}()
 	store.targetMsgSeqNum++
 	return nil
 }


### PR DESCRIPTION
Go Taker/Quickfix had 3 Bottlenecks in terms of ER processing:

1. The ER Channel in the Go Taker was too small and getting blocked
2. The Quickfix Incoming Channel was not buffered and would get blocked
3. The Quicfix Seqnum persistence is super slow

This PR is purely to show the instrumentation and the fixes and is not meant to be merged