### PR TITLE
Sending time accuracy fixes

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/net/proxy"
 )
 
+var bufferedChanSize = 10000
+
 //Initiator initiates connections and processes messages for all sessions.
 type Initiator struct {
 	app             Application
@@ -174,8 +176,8 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			netConn = tlsConn
 		}
 
-		msgIn = make(chan fixIn)
-		msgOut = make(chan []byte)
+		msgIn = make(chan fixIn, bufferedChanSize)
+		msgOut = make(chan []byte, bufferedChanSize)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
 			goto reconnect

--- a/sqlstore_test.go
+++ b/sqlstore_test.go
@@ -56,7 +56,7 @@ TargetCompID=%s`, sqlDriver, sqlDsn, sessionID.BeginString, sessionID.SenderComp
 	require.Nil(suite.T(), err)
 
 	// create store
-	suite.msgStore, err = NewSQLStoreFactory(settings).Create(sessionID)
+	suite.msgStore, err = NewSQLStoreFactory(settings, time.Nanosecond).Create(sessionID)
 	require.Nil(suite.T(), err)
 }
 


### PR DESCRIPTION
Go Taker/Quickfix had 3 Bottlenecks in terms of ER processing:

1. The ER Channel in the Go Taker was too small and getting blocked
2. The Quickfix Incoming Channel was not buffered and would get blocked
3. The Quicfix Seqnum persistence is super slow

This PR addresses bottlenecks 2 and 3